### PR TITLE
fix(markdown): preserve inline content on save

### DIFF
--- a/internal/markdown/ast.go
+++ b/internal/markdown/ast.go
@@ -26,17 +26,23 @@ type TodoNode struct {
 	Checked  bool
 }
 
+func newMarkdownParser() goldmark.Markdown {
+	// Linkify turns source text into childless AutoLink nodes. The editor does
+	// not need HTML-style linkification, and retaining text nodes preserves the
+	// exact URL or email spelling through mutations and serialization.
+	return goldmark.New(
+		goldmark.WithExtensions(
+			extension.Table,
+			extension.Strikethrough,
+			extension.TaskList,
+		),
+	)
+}
+
 // ParseAST parses markdown content into a goldmark AST
 func ParseAST(content string) (*ASTDocument, error) {
 	source := []byte(content)
-
-	// Create parser with GFM extension for task list support
-	md := goldmark.New(
-		goldmark.WithExtensions(
-			extension.GFM, // GitHub Flavored Markdown
-		),
-	)
-
+	md := newMarkdownParser()
 	doc := md.Parser().Parse(text.NewReader(source))
 
 	return &ASTDocument{
@@ -267,6 +273,18 @@ func (doc *ASTDocument) extractTodoText(listItem ast.Node, checkbox ast.Node) st
 					buf.WriteByte(')')
 					return ast.WalkSkipChildren, nil
 				}
+			case *ast.AutoLink:
+				if entering {
+					buf.WriteByte('<')
+					buf.Write(node.Label(doc.Source))
+					buf.WriteByte('>')
+					return ast.WalkSkipChildren, nil
+				}
+			case *ast.RawHTML:
+				if entering {
+					buf.Write(node.Segments.Value(doc.Source))
+					return ast.WalkSkipChildren, nil
+				}
 			case *ast.Emphasis:
 				// Could preserve emphasis markers if needed
 			}
@@ -354,110 +372,24 @@ func (doc *ASTDocument) UpdateTodoText(todoIndex int, newText string) error {
 		return err
 	}
 
-	// Get the list item and its parent
-	listItem := node.ListItem
-	parentList := listItem.Parent()
-	if parentList == nil {
-		return fmt.Errorf("list item has no parent")
+	container := node.CheckBox.Parent()
+	if container == nil {
+		return fmt.Errorf("todo checkbox has no text container")
 	}
 
-	// Find the position of this list item in its parent
-	var prevSibling ast.Node
-	for child := parentList.FirstChild(); child != nil; child = child.NextSibling() {
-		if child == listItem {
-			break
+	for child := container.FirstChild(); child != nil; {
+		next := child.NextSibling()
+		if child != node.CheckBox {
+			container.RemoveChild(container, child)
 		}
-		prevSibling = child
+		child = next
 	}
-
-	// Create a complete markdown list item with checkbox to parse properly
-	var tempMarkdown string
-	if node.CheckBox.IsChecked {
-		tempMarkdown = "- [x] " + newText
-	} else {
-		tempMarkdown = "- [ ] " + newText
+	if newText != "" {
+		start := len(doc.Source)
+		doc.Source = append(doc.Source, newText...)
+		container.AppendChild(container, ast.NewTextSegment(text.NewSegment(start, len(doc.Source))))
 	}
-
-	// Append to source
-	sourceStart := len(doc.Source)
-	doc.Source = append(doc.Source, []byte(tempMarkdown)...)
-
-	// Parse as a complete list item to get proper inline element handling
-	md := goldmark.New(
-		goldmark.WithExtensions(
-			extension.GFM,
-		),
-	)
-	tempDoc := md.Parser().Parse(text.NewReader([]byte(tempMarkdown)))
-
-	// Find the parsed list item
-	var newListItem *ast.ListItem
-	_ = ast.Walk(tempDoc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
-		if !entering || newListItem != nil {
-			return ast.WalkContinue, nil
-		}
-
-		if li, ok := n.(*ast.ListItem); ok {
-			// Verify it has a checkbox
-			hasCheckbox := false
-			_ = ast.Walk(li, func(child ast.Node, entering bool) (ast.WalkStatus, error) {
-				if entering && child.Kind() == extast.KindTaskCheckBox {
-					hasCheckbox = true
-					return ast.WalkStop, nil
-				}
-				return ast.WalkContinue, nil
-			})
-			if hasCheckbox {
-				newListItem = li
-				return ast.WalkStop, nil
-			}
-		}
-
-		return ast.WalkContinue, nil
-	})
-
-	if newListItem == nil {
-		return fmt.Errorf("failed to parse new todo text")
-	}
-
-	// Detach from temp document
-	if newListItem.Parent() != nil {
-		newListItem.Parent().RemoveChild(newListItem.Parent(), newListItem)
-	}
-
-	// Adjust all segments to point to our source
-	adjustNodeSegments(newListItem, sourceStart)
-
-	// Replace old list item with new one
-	parentList.RemoveChild(parentList, listItem)
-
-	if prevSibling == nil {
-		// Insert at beginning
-		if parentList.FirstChild() != nil {
-			parentList.InsertBefore(parentList, parentList.FirstChild(), newListItem)
-		} else {
-			parentList.AppendChild(parentList, newListItem)
-		}
-	} else {
-		// Insert after previous sibling
-		parentList.InsertAfter(parentList, prevSibling, newListItem)
-	}
-
 	return nil
-}
-
-// adjustNodeSegments recursively adjusts all segment positions in a node tree
-func adjustNodeSegments(node ast.Node, offset int) {
-	// Adjust this node's segment if it has one
-	if n, ok := node.(*ast.Text); ok {
-		seg := n.Segment
-		n.Segment = text.NewSegment(seg.Start+offset, seg.Stop+offset)
-	}
-
-	// Recursively adjust children
-	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-		adjustNodeSegments(child, offset)
-	}
 }
 
 // DeleteTodo removes a todo from the AST, promoting any children to the parent level

--- a/internal/markdown/ast.go
+++ b/internal/markdown/ast.go
@@ -227,6 +227,9 @@ func (doc *ASTDocument) extractTodoText(listItem ast.Node, checkbox ast.Node) st
 			if n.Kind() == ast.KindList {
 				return ast.WalkSkipChildren, nil
 			}
+			if entering && writeInlineNodeText(&buf, doc, n) {
+				return ast.WalkSkipChildren, nil
+			}
 
 			// Collect text content
 			switch node := n.(type) {
@@ -271,18 +274,6 @@ func (doc *ASTDocument) extractTodoText(listItem ast.Node, checkbox ast.Node) st
 					buf.WriteByte('(')
 					buf.Write(node.Destination)
 					buf.WriteByte(')')
-					return ast.WalkSkipChildren, nil
-				}
-			case *ast.AutoLink:
-				if entering {
-					buf.WriteByte('<')
-					buf.Write(node.Label(doc.Source))
-					buf.WriteByte('>')
-					return ast.WalkSkipChildren, nil
-				}
-			case *ast.RawHTML:
-				if entering {
-					buf.Write(node.Segments.Value(doc.Source))
 					return ast.WalkSkipChildren, nil
 				}
 			case *ast.Emphasis:

--- a/internal/markdown/inline_preservation_test.go
+++ b/internal/markdown/inline_preservation_test.go
@@ -1,0 +1,101 @@
+package markdown
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUnrelatedTogglePreservesInlineMarkdownOnDisk(t *testing.T) {
+	isolateSaveLocks(t)
+	path := filepath.Join(t.TempDir(), "todo.md")
+	content := strings.Join([]string{
+		"# Todos",
+		"",
+		"- [ ] toggle me",
+		"- [ ] bare https://example.com/path?q=1#fragment",
+		"- [ ] www www.example.com/path",
+		"- [ ] email user@example.com",
+		"- [ ] angle <https://example.com/path>",
+		"- [ ] angle email <user@example.com>",
+		`- [ ] html <span data-x="1">value</span>`,
+		"- [ ] image ![alt](https://example.com/image.png)",
+		"- [ ] strike ~~removed~~",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fm, err := ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fm.UpdateTodoItem(0, fm.Todos[0].Text, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(path, fm); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Replace(content, "- [ ] toggle me", "- [x] toggle me", 1)
+	if string(got) != want {
+		t.Fatalf("saved markdown changed unrelated inline content:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+}
+
+func TestExtractTodosPreservesAutolinksAndRawHTML(t *testing.T) {
+	content := strings.Join([]string{
+		"- [ ] angle <https://example.com/path>",
+		"- [ ] email <user@example.com>",
+		`- [ ] html <kbd data-key="x">X</kbd>`,
+		"",
+	}, "\n")
+	fm := ParseMarkdown(content)
+	want := []string{
+		"angle <https://example.com/path>",
+		"email <user@example.com>",
+		`html <kbd data-key="x">X</kbd>`,
+	}
+	if len(fm.Todos) != len(want) {
+		t.Fatalf("todo count = %d, want %d", len(fm.Todos), len(want))
+	}
+	for i, expected := range want {
+		if fm.Todos[i].Text != expected {
+			t.Errorf("todo %d text = %q, want %q", i, fm.Todos[i].Text, expected)
+		}
+	}
+}
+
+func TestUpdateTodoTextPreservesLinkLikeText(t *testing.T) {
+	tests := []string{
+		"bare http://example.com/path",
+		"secure https://example.com/path?q=1#fragment",
+		"ftp ftp://example.com/file.txt",
+		"www www.example.com/path",
+		"email user@example.com",
+		"angle <https://example.com/path>",
+		"angle email <user@example.com>",
+		`html <span class="value">text</span>`,
+	}
+	for _, text := range tests {
+		t.Run(text, func(t *testing.T) {
+			fm := ParseMarkdown("# Todos\n\n- [ ] placeholder\n")
+			if err := fm.UpdateTodoItem(0, text, false); err != nil {
+				t.Fatal(err)
+			}
+			if fm.Todos[0].Text != text {
+				t.Fatalf("updated text = %q, want %q", fm.Todos[0].Text, text)
+			}
+			roundTripped := ParseMarkdown(SerializeMarkdown(fm))
+			if roundTripped.Todos[0].Text != text {
+				t.Fatalf("round-tripped text = %q, want %q", roundTripped.Todos[0].Text, text)
+			}
+		})
+	}
+}

--- a/internal/markdown/serializer.go
+++ b/internal/markdown/serializer.go
@@ -192,6 +192,14 @@ func serializeNode(doc *ASTDocument, node ast.Node, buf *bytes.Buffer, depth int
 		}
 		buf.WriteString(")")
 
+	case *ast.AutoLink:
+		buf.WriteString("<")
+		buf.Write(n.Label(doc.Source))
+		buf.WriteString(">")
+
+	case *ast.RawHTML:
+		buf.Write(n.Segments.Value(doc.Source))
+
 	case *ast.Emphasis:
 		// Check emphasis level
 		if n.Level == 2 {

--- a/internal/markdown/serializer.go
+++ b/internal/markdown/serializer.go
@@ -16,7 +16,25 @@ func SerializeAST(doc *ASTDocument) string {
 	return buf.String()
 }
 
+func writeInlineNodeText(buf *bytes.Buffer, doc *ASTDocument, node ast.Node) bool {
+	switch n := node.(type) {
+	case *ast.AutoLink:
+		buf.WriteByte('<')
+		buf.Write(n.Label(doc.Source))
+		buf.WriteByte('>')
+		return true
+	case *ast.RawHTML:
+		buf.Write(n.Segments.Value(doc.Source))
+		return true
+	default:
+		return false
+	}
+}
+
 func serializeNode(doc *ASTDocument, node ast.Node, buf *bytes.Buffer, depth int) {
+	if writeInlineNodeText(buf, doc, node) {
+		return
+	}
 	switch n := node.(type) {
 	case *ast.Document:
 		// Serialize all children
@@ -191,14 +209,6 @@ func serializeNode(doc *ASTDocument, node ast.Node, buf *bytes.Buffer, depth int
 			buf.WriteString(`"`)
 		}
 		buf.WriteString(")")
-
-	case *ast.AutoLink:
-		buf.WriteString("<")
-		buf.Write(n.Label(doc.Source))
-		buf.WriteString(">")
-
-	case *ast.RawHTML:
-		buf.Write(n.Segments.Value(doc.Source))
 
 	case *ast.Emphasis:
 		// Check emphasis level


### PR DESCRIPTION
## Summary

- preserve bare URLs, www links, email addresses, angle-bracket autolinks, and inline HTML during unrelated todo saves
- retain source text instead of applying Goldmark's presentation-only Linkify transform in the editable AST
- simplify todo text replacement to avoid fragile segment rebasing
- add disk-level, extraction, and edit round-trip regression coverage

## Root cause

Goldmark's GFM Linkify extension converts URL-like source text into childless `ast.AutoLink` nodes. The custom extractor and serializer handled `ast.Link` but not these nodes, so any later save silently omitted them. Raw HTML used the same childless-node path, and edited autolinks also exposed incorrect segment rebasing.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- repeated inline-preservation tests
- Linux and Windows markdown test cross-compiles
- reporter's original CLI reproduction

Fixes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preservation of inline Markdown when extracting and updating todo items.
  - Autolinks, raw HTML, URLs, email addresses, and angle-bracketed text now remain intact.
  - Editing or toggling one todo no longer alters unrelated inline formatting or content.
  - Todo updates now remain consistent after saving and reloading the document.

- **Tests**
  - Added coverage for inline Markdown preservation during todo extraction, updates, and round-trip serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->