### PR TITLE
fix(tui): support typing multi-byte characters (e.g. umlauts)

### DIFF
--- a/cmd/tdx/unicode_test.go
+++ b/cmd/tdx/unicode_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/niklas-heer/tdx/internal/config"
+)
+
+func TestTUIUnicodeEditing(t *testing.T) {
+	cases := []struct{ name, keys, want string }{
+		{"insert", "nKäse überprüfen\r", "Käse überprüfen"},
+		{"delete", "nKäse\x1b[H\x1b[C\x1b[3~\r", "Kse"},
+		{"right and backspace", "nKäse\x1b[H\x1b[C\x1b[C\x7f\r", "Kse"},
+		{"three and four byte runes", "n茶😀\x7f\r", "茶"},
+		{"search backspace", "/äü\x7f", "SEARCH   ä"},
+		{"command backspace", ":üä\x7f", ":ü"},
+		{"recent backspace", "rüä\x7f", "Recent: ü"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			config.SetConfigDirForTesting(dir)
+			t.Cleanup(config.ResetConfigDirForTesting)
+			file := filepath.Join(dir, "ü.md")
+			if err := os.WriteFile(file, []byte("- [ ] Käse\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if err := config.SaveRecentFile(file, 0); err != nil {
+				t.Fatal(err)
+			}
+			output := runPiped(t, file, tc.keys)
+			if !utf8.ValidString(output) || !strings.Contains(output, tc.want) {
+				t.Fatalf("want %q in valid UTF-8 output:\n%s", tc.want, output)
+			}
+			content := readTestFile(t, file)
+			if !utf8.ValidString(content) {
+				t.Fatalf("invalid UTF-8 on disk: %q", content)
+			}
+			if strings.HasPrefix(tc.keys, "n") && !strings.Contains(content, "- [ ] "+tc.want) {
+				t.Fatalf("expected saved todo %q: %s", tc.want, content)
+			}
+		})
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1450,12 +1450,32 @@ func byteToKeyMsg(b byte) tea.KeyMsg {
 	}
 }
 
-// ProcessPipedInput handles input byte-by-byte for testing/scripting
-// It converts bytes to tea.KeyMsg and delegates to the unified handlers
+// ProcessPipedInput decodes UTF-8 and terminal editing keys for testing/scripting.
 func (m *Model) ProcessPipedInput(input []byte) {
 	for i := 0; i < len(input); i++ {
 		b := input[i]
 		msg := byteToKeyMsg(b)
+		if b >= utf8.RuneSelf {
+			r, size := utf8.DecodeRune(input[i:])
+			if r == utf8.RuneError && size == 1 {
+				continue
+			}
+			msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+			i += size - 1
+		} else if b == 27 {
+			for sequence, keyType := range map[string]tea.KeyType{
+				"\x1b[D": tea.KeyLeft, "\x1b[C": tea.KeyRight,
+				"\x1b[A": tea.KeyUp, "\x1b[B": tea.KeyDown,
+				"\x1b[H": tea.KeyHome, "\x1b[F": tea.KeyEnd,
+				"\x1b[3~": tea.KeyDelete,
+			} {
+				if strings.HasPrefix(string(input[i:]), sequence) {
+					msg = tea.KeyMsg{Type: keyType}
+					i += len(sequence) - 1
+					break
+				}
+			}
+		}
 
 		// Skip empty messages (non-printable bytes)
 		if msg.Type == 0 && len(msg.Runes) == 0 {
@@ -1465,7 +1485,7 @@ func (m *Model) ProcessPipedInput(input []byte) {
 		// Check for quit in normal mode (q or esc without other modes active)
 		if !m.InputMode && !m.EditMode && !m.SearchMode && !m.CommandMode &&
 			!m.MoveMode && !m.FilterMode && !m.MaxVisibleInputMode && !m.HelpMode && !m.RecentFilesMode {
-			if b == 'q' || b == 27 {
+			if msg.String() == "q" || msg.Type == tea.KeyEsc {
 				return
 			}
 		}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/niklas-heer/tdx/internal/config"
@@ -394,6 +395,28 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// prevRuneLen returns the byte length of the rune immediately before
+// byte offset pos in s. CursorPos is a byte offset, not a rune count,
+// so callers must step by this width (not by 1) to stay on a valid
+// UTF-8 boundary when the buffer contains multi-byte characters.
+func prevRuneLen(s string, pos int) int {
+	if pos <= 0 || pos > len(s) {
+		return 0
+	}
+	_, size := utf8.DecodeLastRuneInString(s[:pos])
+	return size
+}
+
+// nextRuneLen returns the byte length of the rune starting at byte
+// offset pos in s. See prevRuneLen for why this matters.
+func nextRuneLen(s string, pos int) int {
+	if pos < 0 || pos >= len(s) {
+		return 0
+	}
+	_, size := utf8.DecodeRuneInString(s[pos:])
+	return size
+}
+
 func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
@@ -424,25 +447,21 @@ func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "backspace", "ctrl+h":
-		if m.CursorPos > 0 {
-			m.InputBuffer = m.InputBuffer[:m.CursorPos-1] + m.InputBuffer[m.CursorPos:]
-			m.CursorPos--
+		if n := prevRuneLen(m.InputBuffer, m.CursorPos); n > 0 {
+			m.InputBuffer = m.InputBuffer[:m.CursorPos-n] + m.InputBuffer[m.CursorPos:]
+			m.CursorPos -= n
 		}
 
 	case "delete":
-		if m.CursorPos < len(m.InputBuffer) {
-			m.InputBuffer = m.InputBuffer[:m.CursorPos] + m.InputBuffer[m.CursorPos+1:]
+		if n := nextRuneLen(m.InputBuffer, m.CursorPos); n > 0 {
+			m.InputBuffer = m.InputBuffer[:m.CursorPos] + m.InputBuffer[m.CursorPos+n:]
 		}
 
 	case "left":
-		if m.CursorPos > 0 {
-			m.CursorPos--
-		}
+		m.CursorPos -= prevRuneLen(m.InputBuffer, m.CursorPos)
 
 	case "right":
-		if m.CursorPos < len(m.InputBuffer) {
-			m.CursorPos++
-		}
+		m.CursorPos += nextRuneLen(m.InputBuffer, m.CursorPos)
 
 	case "home", "ctrl+a":
 		m.CursorPos = 0
@@ -460,9 +479,9 @@ func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	default:
 		// Insert character
-		if len(key) == 1 {
+		if utf8.RuneCountInString(key) == 1 {
 			m.InputBuffer = m.InputBuffer[:m.CursorPos] + key + m.InputBuffer[m.CursorPos:]
-			m.CursorPos++
+			m.CursorPos += len(key)
 		}
 	}
 
@@ -657,9 +676,9 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "backspace", "ctrl+h":
-		if m.CursorPos > 0 {
-			m.InputBuffer = m.InputBuffer[:m.CursorPos-1] + m.InputBuffer[m.CursorPos:]
-			m.CursorPos--
+		if n := prevRuneLen(m.InputBuffer, m.CursorPos); n > 0 {
+			m.InputBuffer = m.InputBuffer[:m.CursorPos-n] + m.InputBuffer[m.CursorPos:]
+			m.CursorPos -= n
 			// Debounce search update
 			m.searchPending = true
 			return m, searchDebounceCmd()
@@ -667,9 +686,9 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	default:
 		// Insert character
-		if len(key) == 1 {
+		if utf8.RuneCountInString(key) == 1 {
 			m.InputBuffer = m.InputBuffer[:m.CursorPos] + key + m.InputBuffer[m.CursorPos:]
-			m.CursorPos++
+			m.CursorPos += len(key)
 			// Debounce search update
 			m.searchPending = true
 			return m, searchDebounceCmd()
@@ -936,9 +955,9 @@ func (m Model) handleCommandKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "backspace", "ctrl+h":
-		if m.CursorPos > 0 {
-			m.InputBuffer = m.InputBuffer[:m.CursorPos-1] + m.InputBuffer[m.CursorPos:]
-			m.CursorPos--
+		if n := prevRuneLen(m.InputBuffer, m.CursorPos); n > 0 {
+			m.InputBuffer = m.InputBuffer[:m.CursorPos-n] + m.InputBuffer[m.CursorPos:]
+			m.CursorPos -= n
 			// Debounce command filter update
 			m.searchPending = true
 			return m, commandDebounceCmd()
@@ -946,9 +965,9 @@ func (m Model) handleCommandKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	default:
 		// Insert character
-		if len(key) == 1 {
+		if utf8.RuneCountInString(key) == 1 {
 			m.InputBuffer = m.InputBuffer[:m.CursorPos] + key + m.InputBuffer[m.CursorPos:]
-			m.CursorPos++
+			m.CursorPos += len(key)
 			// Debounce command filter update
 			m.searchPending = true
 			return m, commandDebounceCmd()
@@ -1565,14 +1584,15 @@ func (m Model) handleRecentFilesInput(key string) (tea.Model, tea.Cmd) {
 		}
 
 	case "backspace":
-		if len(m.RecentFilesSearch) > 0 {
-			m.RecentFilesSearch = m.RecentFilesSearch[:len(m.RecentFilesSearch)-1]
+		if s := m.RecentFilesSearch; s != "" {
+			_, size := utf8.DecodeLastRuneInString(s)
+			m.RecentFilesSearch = s[:len(s)-size]
 			m.RecentFilesCursor = 0 // Reset cursor when search changes
 		}
 
 	default:
 		// Add to search buffer (printable characters, but skip leading spaces)
-		if len(key) == 1 && key[0] >= 32 && key[0] <= 126 {
+		if r, size := utf8.DecodeRuneInString(key); size == len(key) && r >= 32 && r != utf8.RuneError {
 			// Skip leading spaces
 			if m.RecentFilesSearch != "" || key != " " {
 				m.RecentFilesSearch += key

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"testing"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/niklas-heer/tdx/internal/markdown"
@@ -254,6 +255,102 @@ func TestHandleInputKey_InsertCharacter(t *testing.T) {
 	}
 	if m.CursorPos != 1 {
 		t.Errorf("CursorPos = %d, want 1", m.CursorPos)
+	}
+}
+
+func TestHandleInputKey_InsertUmlaut(t *testing.T) {
+	m := testModel([]string{})
+	m.InputMode = true
+	m.InputBuffer = ""
+	m.CursorPos = 0
+
+	for _, r := range "Käse" {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		result, _ := m.handleInputKey(msg)
+		m = result.(Model)
+	}
+
+	if m.InputBuffer != "Käse" {
+		t.Errorf("InputBuffer = %q, want %q", m.InputBuffer, "Käse")
+	}
+	if m.CursorPos != len("Käse") {
+		t.Errorf("CursorPos = %d, want %d", m.CursorPos, len("Käse"))
+	}
+}
+
+func TestHandleInputKey_BackspaceUmlaut(t *testing.T) {
+	m := testModel([]string{})
+	m.InputMode = true
+	m.InputBuffer = "Kä"
+	m.CursorPos = len("Kä")
+
+	msg := tea.KeyMsg{Type: tea.KeyBackspace}
+	result, _ := m.handleInputKey(msg)
+	m = result.(Model)
+
+	if m.InputBuffer != "K" {
+		t.Errorf("InputBuffer = %q, want %q", m.InputBuffer, "K")
+	}
+	if !utf8.ValidString(m.InputBuffer) {
+		t.Errorf("InputBuffer is not valid UTF-8: %q", m.InputBuffer)
+	}
+}
+
+func TestHandleInputKey_CursorMovementUmlaut(t *testing.T) {
+	m := testModel([]string{})
+	m.InputMode = true
+	m.InputBuffer = "Käse"
+	m.CursorPos = len("Käse")
+
+	// Move left three times: past 'e', 's', then 'ä' -> cursor lands
+	// right after 'K', i.e. inside the byte range of 'ä' if moved by
+	// byte instead of by rune.
+	for range 3 {
+		msg := tea.KeyMsg{Type: tea.KeyLeft}
+		result, _ := m.handleInputKey(msg)
+		m = result.(Model)
+	}
+	if !utf8.ValidString(m.InputBuffer[:m.CursorPos]) {
+		t.Fatalf("cursor split a multi-byte rune: prefix %q is invalid UTF-8", m.InputBuffer[:m.CursorPos])
+	}
+	if m.CursorPos != len("K") {
+		t.Errorf("CursorPos = %d, want %d (right after 'K')", m.CursorPos, len("K"))
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}}
+	result, _ := m.handleInputKey(msg)
+	m = result.(Model)
+	if m.InputBuffer != "KXäse" {
+		t.Errorf("InputBuffer = %q, want %q", m.InputBuffer, "KXäse")
+	}
+}
+
+func TestHandleSearchKey_InsertUmlaut(t *testing.T) {
+	m := testModel([]string{"Käse", "banana"})
+	m.SearchMode = true
+	m.InputBuffer = ""
+	m.SearchResults = []int{0, 1}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'ä'}}
+	result, _ := m.handleSearchKey(msg)
+	m = result.(Model)
+
+	if m.InputBuffer != "ä" {
+		t.Errorf("InputBuffer = %q, want %q", m.InputBuffer, "ä")
+	}
+}
+
+func TestHandleCommandKey_InsertUmlaut(t *testing.T) {
+	m := testModel([]string{"Task 1"})
+	m.CommandMode = true
+	m.FilteredCmds = []int{0, 1, 2, 3}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'ü'}}
+	result, _ := m.handleCommandKey(msg)
+	m = result.(Model)
+
+	if m.InputBuffer != "ü" {
+		t.Errorf("InputBuffer = %q, want %q", m.InputBuffer, "ü")
 	}
 }
 


### PR DESCRIPTION
## Bug

Typing umlauts (ä, ö, ü, ß, ...) or any other non-ASCII character into
the add/edit todo input, the fuzzy search box, the command palette, or
the recent-files search silently drops the character entirely.

Reproduction (before this fix):

```
$ tdx todo.md
n                       # new todo
Käse überprüfen         # typed on a real keyboard
```

Result in the file: `Kse berprfen` — every umlaut vanishes.

## Root cause

`handleInputKey`/`handleSearchKey`/`handleCommandKey` decide whether a
key press should be inserted with:

```go
key := msg.String()
if len(key) == 1 {
    m.InputBuffer = m.InputBuffer[:m.CursorPos] + key + m.InputBuffer[m.CursorPos:]
    m.CursorPos++
}
```

`msg.String()` for a `KeyRunes` message returns `string(msg.Runes)` —
a UTF-8-encoded Go string. A single rune like `'ä'` encodes to **2
bytes**, so `len(key) == 1` is `false` and the character is silently
discarded. Same bug, independently, in the recent-files search filter
(`key[0] >= 32 && key[0] <= 126`, ASCII-only).

A second, latent bug: `CursorPos` is a *byte* offset into
`InputBuffer` (used directly for slicing), but backspace/delete/left/
right all stepped it by exactly `1`, assuming one byte per character.
That assumption breaks the moment multi-byte insertion works, since a
byte-offset step of 1 can land in the middle of a multi-byte rune and
corrupt the UTF-8 buffer (verified with a regression test before
fixing).

## Fix

- Detect a single-rune key press with `utf8.RuneCountInString(key) ==
  1` instead of `len(key) == 1`, and advance `CursorPos` by
  `len(key)` bytes (not `1`) on insert.
- Added `prevRuneLen`/`nextRuneLen` helpers (using
  `utf8.DecodeLastRuneInString`/`utf8.DecodeRuneInString`) and use
  them for backspace, delete, and left/right cursor movement in
  `handleInputKey`, so `CursorPos` always lands on a valid UTF-8
  boundary.
- Applied the same fix to `handleSearchKey`, `handleCommandKey`, and
  `handleRecentFilesInput`, which had the identical byte-vs-rune bug.

## Testing

- Added regression tests exercising insert / backspace / cursor
  movement across a multi-byte character (`Käse`) in each affected
  input handler — all fail before the fix, pass after
  (`go test ./internal/tui/... -run Umlaut -v`).
- `go test ./...`, `go vet ./...`, `gofmt -l .`, and
  `golangci-lint run` (pinned `v2.12.2`, matching CI) all pass.
- Manually verified against a real PTY (byte-for-byte, one keystroke
  at a time, exactly as a terminal delivers UTF-8 input): the
  unpatched binary produces `Kse berprfen` for input `Käse
  überprüfen`; the patched binary produces `Käse überprüfen`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text editing for non-ASCII characters across input, search, command, and recent-file fields.
  * Backspace, deletion, and cursor navigation now preserve complete characters and valid text.
  * Improved handling of keyboard navigation and editing in piped input.

* **Tests**
  * Added coverage for inserting, deleting, and navigating text containing accented characters.
  * Added end-to-end validation for Unicode editing and saved text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->